### PR TITLE
Fix OData specification url pointing to 404

### DIFF
--- a/Odata-docs/index.yml
+++ b/Odata-docs/index.yml
@@ -62,7 +62,7 @@ sections:
         alt: OData specification
         src: https://docs.microsoft.com/media/common/i_policy.svg
       title: OData specification
-    - href: https://docs.microsoft.com/en-us/dotnet/api/overview/odata-dotnet/odata-dotnet
+    - href: https://docs.microsoft.com/en-us/dotnet/api/overview/odata-dotnet
       html: <p>Find technical documentation on OData APIs</p>
       image:
         alt: OData technical reference documentation


### PR DESCRIPTION
Current link (lands on 404)
https://docs.microsoft.com/en-us/dotnet/api/overview/odata-dotnet/odata-dotnet
![image](https://user-images.githubusercontent.com/46479127/63786493-77428600-c8f2-11e9-9da4-75553144d426.png)


New suggested working link (with possible duplicated last segment removed)
https://docs.microsoft.com/en-us/dotnet/api/overview/odata-dotnet