### PR TITLE
Fix typo in Built-In Routing Conventions

### DIFF
--- a/Odata-docs/webapi/built-in-routing-conventions.md
+++ b/Odata-docs/webapi/built-in-routing-conventions.md
@@ -22,7 +22,7 @@ For example: `https://example.com/odata/Products(1)/Supplier?$top=2 `
 
 * *The service root* : https://example.com/odata
 * *The OData path* : Products(1)/Supplier
-* *Que OData ons* : ?$top=2  
+* *Query options* : ?$top=2  
 
 
 For OData routing, the important part is the OData path. The OData path is divided into segments, each segments are seperated with '/'.


### PR DESCRIPTION
Looks like this line was accidentally modified with the line above by d040956d4112a903044c9b842a91fa6ec0c66751 - I replaced the line from the previous revision.