### PR TITLE
Fix markdown formatting around ODataUriResolver

### DIFF
--- a/Odata-docs/webapi/enable-no-dollar-queryoptions.md
+++ b/Odata-docs/webapi/enable-no-dollar-queryoptions.md
@@ -26,7 +26,7 @@ A public Boolean attribute EnableNoDollarQueryOptions is added to ODataUriResolv
         public virtual bool EnableNoDollarQueryOptions { get; set; }
         ...
     }
-~~~
+```
 
 ### WebAPI optional-$-prefix Setting using Dependency Injection
 WebAPI service injects the setting using the ODataUriResolver during service initialization:
@@ -37,7 +37,6 @@ Builder of service provider container sets the instantiated ODataUriResolver con
             {
                 EnableNoDollarQueryOptions = true,
                 EnableCaseInsensitive = enableCaseInsensitive
-
             };
 
 spContainerBuilder.AddService(ServiceLifetime.Singleton, sp => resolver));


### PR DESCRIPTION
Code block was closed incorrectly. Also removes an extra line of whitespace in the `ODataUriResolver` constructor block.