### PR TITLE
Add batch relative uri docs

### DIFF
--- a/Odata-docs/client/v6/batch-operations.md
+++ b/Odata-docs/client/v6/batch-operations.md
@@ -166,7 +166,7 @@ The request Payload is as following:
 ```
 
 ## Relative URIs in Batch Requests
-There are instances where an odata service is behind a load balancer which usually rewrites the outer Uri but not the internal URIs such that the request going out from the client looks like:
+There are instances where an odata service is behind a load balancer which usually rewrites the outer URI but not the internal URIs such that the request going out from the client looks like:
 
 ```html
 	POST https://myservice.com/$batch HTTP/1.1

--- a/Odata-docs/client/v6/batch-operations.md
+++ b/Odata-docs/client/v6/batch-operations.md
@@ -221,7 +221,7 @@ var batchResponse = dsc.ExecuteBatch(SaveChangesOptions.BatchWithIndependentOper
 ```
 The same options apply to `ExecuteBatchAsync` method.
 
-### Relative Uris in Batch Modification
+### Relative URIs in Batch Modification
 We can pass the `SaveChangesOptions.UseRelativeUri` option along with other batch options to `SaveChanges` method as follows.
 
 ```

--- a/Odata-docs/client/v6/batch-operations.md
+++ b/Odata-docs/client/v6/batch-operations.md
@@ -164,3 +164,102 @@ The request Payload is as following:
 	--changeset_b98a784d-af07-4723-9d5c-4722801f4c4d--
 	--batch_06d8a02a-854a-4a21-8e5c-f737bbd2dea8--
 ```
+
+## Relative Uris in Batch Requests
+There are instances where an odata service is behind a load balancer which usually rewrites the outer Uri but not the internal URIs such that the request going out from the client looks like:
+
+```html
+	POST https://myservice.com/$batch HTTP/1.1
+
+	--batch_xyz
+	GET https://myservice.com/People HTTP/1.1
+	Content-Type: application/http
+	Content-Transfer-Encoding: binary
+	OData-Version: 4.0
+```
+
+BUT when it hits the load balancer it's rewritten to
+```html
+	POST https://loadbalancer/$batch HTTP/1.1 // changed to loadbalancer uri
+
+	--batch_xyz
+	GET https://myservice.com/People HTTP/1.1 // uri in the body remains unchanged
+	Content-Type: application/http
+	Content-Transfer-Encoding: binary
+	OData-Version: 4.0
+```
+
+While the odata service actually expected
+```html
+	POST https://loadbalancer/$batch HTTP/1.1
+
+	--batch_xyz
+	GET https://loadbalancer/People HTTP/1.1
+	Content-Type: application/http
+	Content-Transfer-Encoding: binary
+	OData-Version: 4.0
+```
+
+But since we cant change the internal batch uri to the load balancer uri, we instead get around the problem by using relative uri's to fix this as follows
+```html
+	POST https://loadbalancer/$batch HTTP/1.1
+
+	--batch_xyz
+	GET /People HTTP/1.1 // uses relative uri
+	Content-Type: application/http
+	Content-Transfer-Encoding: binary
+	OData-Version: 4.0
+```
+
+`ExecuteBatch` and `SaveChanges` defined in `DataServiceContext` accept `SaveChangesOptions.UseRelativeUri` option which allows individual requests in batch to use Relative Uris. In this case, they will rely on the Base Uri of the top level request.
+
+### Relative Uris in Batch Queries
+We can pass the `SaveChangesOptions.UseRelativeUri` option along with other batch options to `ExecuteBatch` method as follows.
+
+```
+var batchResponse = dsc.ExecuteBatch(SaveChangesOptions.BatchWithIndependentOperations | SaveChangesOptions.UseRelativeUri, peopleQuery, airlinesQuery);
+```
+The same options apply to `ExecuteBatchAsync` method.
+
+### Relative Uris in Batch Modification
+We can pass the `SaveChangesOptions.UseRelativeUri` option along with other batch options to `SaveChanges` method as follows.
+
+```
+dsc.SaveChanges(SaveChangesOptions.BatchWithSingleChangeset | SaveChangesOptions.UseRelativeUri);
+```
+The same options apply to `SaveChangesAsync` method.
+
+A truncated request Payload will look like this:
+
+```html
+
+	--batch_06d8a02a-854a-4a21-8e5c-f737bbd2dea8
+	Content-Type: multipart/mixed; boundary=changeset_b98a784d-af07-4723-9d5c-4722801f4c4d
+	.....
+	.....
+	.....
+
+	GET /People HTTP/1.1 // Relative URI is used
+	OData-Version: 4.0
+	OData-MaxVersion: 4.0
+	Accept: application/json;odata.metadata=minimal
+
+	.....
+	.....
+	
+	PATCH /Me HTTP/1.1 // Relative URI is used
+	OData-Version: 4.0
+	OData-MaxVersion: 4.0
+	Content-Type: application/json;odata.metadata=minimal
+	.....
+	.....
+	.....
+
+	PATCH /Me/Trips(1001) HTTP/1.1 // Relative URI is used
+	OData-Version: 4.0
+	OData-MaxVersion: 4.0
+	Content-Type: application/json;odata.metadata=minimal
+	......
+	......
+	......
+```

--- a/Odata-docs/client/v6/batch-operations.md
+++ b/Odata-docs/client/v6/batch-operations.md
@@ -211,7 +211,7 @@ But since we can't change the internal batch URI to the load balancer URI, we in
 	OData-Version: 4.0
 ```
 
-`ExecuteBatch` and `SaveChanges` defined in `DataServiceContext` accept `SaveChangesOptions.UseRelativeUri` option which allows individual requests in batch to use Relative Uris. In this case, they will rely on the Base Uri of the top level request.
+`ExecuteBatch` and `SaveChanges` defined in `DataServiceContext` accept `SaveChangesOptions.UseRelativeUri` option which allows individual requests in batch to use Relative URIs. In this case, they will rely on the Base URI of the top level request.
 
 ### Relative URIs in Batch Queries
 We can pass the `SaveChangesOptions.UseRelativeUri` option along with other batch options to `ExecuteBatch` method as follows.

--- a/Odata-docs/client/v6/batch-operations.md
+++ b/Odata-docs/client/v6/batch-operations.md
@@ -200,7 +200,7 @@ While the odata service actually expected
 	OData-Version: 4.0
 ```
 
-But since we cant change the internal batch uri to the load balancer uri, we instead get around the problem by using relative uri's to fix this as follows
+But since we can't change the internal batch URI to the load balancer URI, we instead get around the problem by using relative URI's to fix this as follows
 ```html
 	POST https://loadbalancer/$batch HTTP/1.1
 

--- a/Odata-docs/client/v6/batch-operations.md
+++ b/Odata-docs/client/v6/batch-operations.md
@@ -165,7 +165,7 @@ The request Payload is as following:
 	--batch_06d8a02a-854a-4a21-8e5c-f737bbd2dea8--
 ```
 
-## Relative Uris in Batch Requests
+## Relative URIs in Batch Requests
 There are instances where an odata service is behind a load balancer which usually rewrites the outer Uri but not the internal URIs such that the request going out from the client looks like:
 
 ```html

--- a/Odata-docs/client/v6/batch-operations.md
+++ b/Odata-docs/client/v6/batch-operations.md
@@ -213,7 +213,7 @@ But since we cant change the internal batch uri to the load balancer uri, we ins
 
 `ExecuteBatch` and `SaveChanges` defined in `DataServiceContext` accept `SaveChangesOptions.UseRelativeUri` option which allows individual requests in batch to use Relative Uris. In this case, they will rely on the Base Uri of the top level request.
 
-### Relative Uris in Batch Queries
+### Relative URIs in Batch Queries
 We can pass the `SaveChangesOptions.UseRelativeUri` option along with other batch options to `ExecuteBatch` method as follows.
 
 ```


### PR DESCRIPTION
Related to this PR https://github.com/OData/odata.net/pull/1675
We have added a feature in OData Client batch operations that allow individual requests in the payload to have relative Uri.