### PR TITLE
Update count query options docs

### DIFF
--- a/Odata-docs/client/v6/query-options.md
+++ b/Odata-docs/client/v6/query-options.md
@@ -49,8 +49,18 @@ var count = context.People.Count();
 
 For `GET https://host/service/EntitySet?$count=true`:
 
+We have two ways of making this request.
 ``` csharp
-var people = context.People.IncludeTotalCount();
+var people = context.People.IncludeCount();
+```
+``` csharp
+var people = context.People.IncludeCount(true);
+```
+
+For `GET https://host/service/EntitySet?$count=false`:
+
+``` csharp
+var people = context.People.IncludeCount(false);
 ```
 
 ## $orderby


### PR DESCRIPTION
Related to this PR https://github.com/OData/odata.net/pull/1658

We have added an `IncludeTotalCount(bool countQuery)`method.
We have also added `IncludeCount()` and `IncludeCount(bool countQuery)` methods and deprecated the `IncludeTotalCount` since `TotalCount` is a V3 term.

For `GET https://host/service/EntitySet?$count=true`:
``` csharp
var people = context.People.IncludeCount();
```
``` csharp
var people = context.People.IncludeCount(true);
```
For `GET https://host/service/EntitySet?$count=false`:
``` csharp
var people = context.People.IncludeCount(false);
```