### PR TITLE
Fix broken link

### DIFF
--- a/Odata-docs/TOC.yml
+++ b/Odata-docs/TOC.yml
@@ -210,7 +210,7 @@
         - name: Customizable type facets promotion in URI parsing
           href: /odata/odatalib/customizable-type-facets-promotion
         - name: Merge complex type and entity type
-          href: /odata/odatalib/merge-complex-and-entity
+          href: /odata/odatalib/merge-complex-and-entity-read-writer
         - name: OData Uri Path Parser Extensibility
           href: /odata/odatalib/uri-parser-path-extensibility
         - name: Override type annotation in serialization


### PR DESCRIPTION
The menu item at the left under https://docs.microsoft.com/en-us/odata/webapi/key-value-binding?view=odata-core-7.0 pointing to https://docs.microsoft.com/en-us/odata/webapi/merge-complex-and-entity?view=odata-core-7.0 returns a 404.

Link changed to point to https://docs.microsoft.com/en-us/odata/webapi/merge-complex-and-entity-read-writer