### PR TITLE
Update OData Connected Service changelog

### DIFF
--- a/Odata-docs/changelog/odataconnectedservice.md
+++ b/Odata-docs/changelog/odataconnectedservice.md
@@ -9,20 +9,57 @@ ms.topic: article
 
 # OData Connected Service changelog
 
-## version 0.6.1 Release
+OData Connected Service extension is available on [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=laylaliu.ODataConnectedService).
+
+## OData Connected Service 0.9.0
+
+### New Features
+* [ [#86](https://github.com/OData/ODataConnectedService/pull/86) ] Support for emitting service metadata to an XML file
+* [ [#100](https://github.com/OData/ODataConnectedService/pull/100) ] Support for excluding schema types from being emitted onto the Connected Service proxy class
+
+### Refinements and Bug Fixes
+* [ [#66](https://github.com/OData/ODataConnectedService/pull/66) ] Use _var_ where the type of variable is clear from the context
+* [ [#97](https://github.com/OData/ODataConnectedService/pull/97) ] Fix multiple prompts when updating Connected Service with proxy split into multiple files
+* [ [#99](https://github.com/OData/ODataConnectedService/pull/99) ] Fix loading of saved configuration options when updating Connected Service/1
+* [ [#101](https://github.com/OData/ODataConnectedService/pull/101) ] Fix caption on Connected Service wizard
+* [ [#102](https://github.com/OData/ODataConnectedService/pull/102) ] Fix loading of saved configuration options when updating Connected Service/2
+
+## OData Connected Service 0.8.0
+
+## New Features
+* [ [#50](https://github.com/OData/ODataConnectedService/pull/50) ] Support for loading configuration settings from a file
+* [ [#69](https://github.com/OData/ODataConnectedService/pull/69) ] Support for saving the configuration wizard state when navigating through the pages
+
+## OData Connected Service 0.7.1
+
+## Bug Fix
+* [ [#77](https://github.com/OData/ODataConnectedService/pull/77) ] Fix bug causing service name to be reset to default value when updating Connected Service
+
+## OData Connected Service 0.7.0
+
+### New Features
+* [ [#31](https://github.com/OData/ODataConnectedService/pull/31) ] Support for web proxy and credentials when fetching metadata behind a network proxy
+* [ [#38](https://github.com/OData/ODataConnectedService/pull/38) ] Support for generating Connected Service proxy for VB.NET
+* [ [#45](https://github.com/OData/ODataConnectedService/pull/45) ] Support for excluding  operation imports from being emitted onto the Connected Service proxy class
+* [ [#68](https://github.com/OData/ODataConnectedService/pull/68) ] Support for loading of service metadata from local file
+
+### Improvements and Bug Fixes
+* [ [#70](https://github.com/OData/ODataConnectedService/pull/70) ] Add Transform Tool paths for both Visual Studio 2017 and 2019
+
+## OData Connected Service 0.6.1
 
 ### Improvements and fixes:
 
 * Bug fix on adding option for a separate metadata file.
 
-## version 0.6.0 Release
+## OData Connected Service 0.6.0
 
 ### New Features:
 
 * Custom Http headers. While generating code you can now pass headers including authorization headers to read your Edmx. 
 * Generation of multiple files. You can now opt to generate code in multiple files.
 
-## version 0.5.0 Release
+## OData Connected Service 0.5.0
 
 OData Connected Service extension v0.5.0 is available on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=laylaliu.ODataConnectedService).
 
@@ -48,7 +85,7 @@ It is therefore advisable to the users of [OData Client Code Generator](https://
 
 ---
 
-## version 0.4.0 Release
+## OData Connected Service 0.4.0
 
 ### New Features:
 * Allows user to make generated types internal

--- a/Odata-docs/changelog/odataconnectedservice.md
+++ b/Odata-docs/changelog/odataconnectedservice.md
@@ -60,10 +60,6 @@ OData Connected Service extension is available on [Visual Studio Marketplace](ht
 
 ## OData Connected Service 0.5.0
 
-OData Connected Service extension v0.5.0 is available on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=laylaliu.ODataConnectedService).
-
-You can install or update the extension for v0.5.0 using Visual Studio Extension manager.
-
 OData Connected Service version 0.5.0 requires ```Microsoft.OData.client version 7.6.3``` or above.
 
 With this release, all the features and fixes available in [OData Client Code Generator](https://marketplace.visualstudio.com/items?itemName=bingl.ODatav4ClientCodeGenerator) have been migrated to OData Conneted service. 

--- a/Odata-docs/changelog/odataconnectedservice.md
+++ b/Odata-docs/changelog/odataconnectedservice.md
@@ -13,11 +13,11 @@ OData Connected Service extension is available on [Visual Studio Marketplace](ht
 
 ## OData Connected Service 0.9.0
 
-### New Features
-* [ [#86](https://github.com/OData/ODataConnectedService/pull/86) ] Support for emitting service metadata to an XML file
+### New Features:
+* [ [#86](https://github.com/OData/ODataConnectedService/pull/86) ] Support emitting of service metadata to an XML file
 * [ [#100](https://github.com/OData/ODataConnectedService/pull/100) ] Support for excluding schema types from being emitted onto the Connected Service proxy class
 
-### Improvements and Bug Fixes
+### Improvements and Bug Fixes:
 * [ [#66](https://github.com/OData/ODataConnectedService/pull/66) ] Use _var_ where the type of variable is clear from the context
 * [ [#97](https://github.com/OData/ODataConnectedService/pull/97) ] Fix multiple prompts when updating Connected Service with proxy split into multiple files
 * [ [#99](https://github.com/OData/ODataConnectedService/pull/99) & [#102](https://github.com/OData/ODataConnectedService/pull/102) ] Fix loading of saved configuration options when updating Connected Service
@@ -25,60 +25,56 @@ OData Connected Service extension is available on [Visual Studio Marketplace](ht
 
 ## OData Connected Service 0.8.0
 
-### New Features
-* [ [#50](https://github.com/OData/ODataConnectedService/pull/50) ] Support for loading configuration settings from a file
-* [ [#69](https://github.com/OData/ODataConnectedService/pull/69) ] Support for saving the configuration wizard state when navigating through the pages
+### New Features:
+* [ [#50](https://github.com/OData/ODataConnectedService/pull/50) ] Support loading of configuration settings from a file
+* [ [#69](https://github.com/OData/ODataConnectedService/pull/69) ] Support saving of configuration wizard state when navigating through the pages
 
 ## OData Connected Service 0.7.1
 
-### Bug Fixes
+### Bug Fixes:
 * [ [#77](https://github.com/OData/ODataConnectedService/pull/77) ] Fix bug causing service name to be reset to default value when updating Connected Service
 
 ## OData Connected Service 0.7.0
 
-### New Features
+### New Features:
 * [ [#31](https://github.com/OData/ODataConnectedService/pull/31) ] Support for web proxy and credentials when fetching metadata behind a network proxy
-* [ [#38](https://github.com/OData/ODataConnectedService/pull/38) ] Support for generating Connected Service proxy for VB.NET
+* [ [#38](https://github.com/OData/ODataConnectedService/pull/38) ] Support generation of Connected Service proxy for VB.NET
 * [ [#45](https://github.com/OData/ODataConnectedService/pull/45) ] Support for excluding  operation imports from being emitted onto the Connected Service proxy class
 * [ [#68](https://github.com/OData/ODataConnectedService/pull/68) ] Support for loading of service metadata from local file
 
-### Improvements and Bug Fixes
+### Improvements and Bug Fixes:
 * [ [#70](https://github.com/OData/ODataConnectedService/pull/70) ] Add Transform Tool paths for both Visual Studio 2017 and 2019
 
 ## OData Connected Service 0.6.1
 
-### Improvements and fixes:
+### Improvements and Bug Fixes:
 
-* Bug fix on adding option for a separate metadata file.
+* [ [#55](https://github.com/OData/ODataConnectedService/pull/55) ] Revert change for supporting emitting of service metadata to XML file to fix a regression
 
 ## OData Connected Service 0.6.0
 
 ### New Features:
-
-* Custom Http headers. While generating code you can now pass headers including authorization headers to read your Edmx. 
-* Generation of multiple files. You can now opt to generate code in multiple files.
+* [ [#46](https://github.com/OData/ODataConnectedService/pull/46) ] Support emitting of service metadata to an XML file
+* [ [#27](https://github.com/OData/ODataConnectedService/pull/27) & [#51](https://github.com/OData/ODataConnectedService/pull/51) ] Support custom Http headers (e.g. authorization headers) when retrieving service metadata
+* [ [#30](https://github.com/OData/ODataConnectedService/pull/30) ] Support splitting of Connected Service proxy into multiple files
 
 ## OData Connected Service 0.5.0
 
-OData Connected Service version 0.5.0 requires ```Microsoft.OData.client version 7.6.3``` or above.
-
-With this release, all the features and fixes available in [OData Client Code Generator](https://marketplace.visualstudio.com/items?itemName=bingl.ODatav4ClientCodeGenerator) have been migrated to OData Conneted service. 
-It is therefore advisable to the users of [OData Client Code Generator](https://marketplace.visualstudio.com/items?itemName=bingl.ODatav4ClientCodeGenerator) to start using ```OData Connected Service``` instead.
-
+### Breaking Changes:
+* [ [#24](https://github.com/OData/ODataConnectedService/pull/24) ] Update Microsoft.OData.Client dependency to version 7.6.3
 
 ### New Features:
+* [ [#23](https://github.com/OData/ODataConnectedService/pull/23) ] Add built-in vocabulary models
+* [ [#26](https://github.com/OData/ODataConnectedService/pull/26) ] Support opening of generated Connected Service proxy files in IDE at completion
+* [ [#32](https://github.com/OData/ODataConnectedService/pull/32) ] Support mocking by making public methods `virtual`
 
-* Upgrade Microsoft.OData.Client to version 7.6.3
-* Added a feature to open the generated files in visual studio after code generation.
-* Enable generated functions to be mockable
-
-### Improvements and fixes:
-
-* Remove Microsoft WCF ToolKit dependency
-* Generate type definitions using their underlying types
-* Migrated all features and fixes from OData Client Code Generator to OData Connected Service
-
----
+### Improvements and Bug Fixes:
+* [ [#22](https://github.com/OData/ODataConnectedService/pull/22) ] Swap `CsdlReader.Parse()` with `CsdlReader.TryParse()`
+* [ [#25](https://github.com/OData/ODataConnectedService/pull/25) ] Use underlying types when generating type definitions
+* [ [#28](https://github.com/OData/ODataConnectedService/pull/28) ] Swap `Dictionary` with `IDictionary` in declarations
+* [ [#33](https://github.com/OData/ODataConnectedService/pull/33) ] Drop Microsoft WCF ToolKit dependency
+* [ [#36](https://github.com/OData/ODataConnectedService/pull/36) ] Update issue templates
+* [ [#37](https://github.com/OData/ODataConnectedService/pull/37) ] Update README, licences and pull-request templates
 
 ## OData Connected Service 0.4.0
 

--- a/Odata-docs/changelog/odataconnectedservice.md
+++ b/Odata-docs/changelog/odataconnectedservice.md
@@ -19,7 +19,7 @@ OData Connected Service extension is available on [Visual Studio Marketplace](ht
 
 ### Improvements and Bug Fixes:
 * [ [#66](https://github.com/OData/ODataConnectedService/pull/66) ] Use _var_ where the type of variable is clear from the context
-* [ [#97](https://github.com/OData/ODataConnectedService/pull/97) ] Fix multiple prompts when updating Connected Service with proxy split into multiple files
+* [ [#97](https://github.com/OData/ODataConnectedService/pull/97) ] Fix multiple prompts when updating Connected Service proxy split into multiple files
 * [ [#99](https://github.com/OData/ODataConnectedService/pull/99) & [#102](https://github.com/OData/ODataConnectedService/pull/102) ] Fix loading of saved configuration options when updating Connected Service
 * [ [#101](https://github.com/OData/ODataConnectedService/pull/101) ] Fix caption on Connected Service wizard
 
@@ -54,9 +54,9 @@ OData Connected Service extension is available on [Visual Studio Marketplace](ht
 ## OData Connected Service 0.6.0
 
 ### New Features:
-* [ [#46](https://github.com/OData/ODataConnectedService/pull/46) ] Support emitting of service metadata to an XML file
 * [ [#27](https://github.com/OData/ODataConnectedService/pull/27) & [#51](https://github.com/OData/ODataConnectedService/pull/51) ] Support custom Http headers (e.g. authorization headers) when retrieving service metadata
 * [ [#30](https://github.com/OData/ODataConnectedService/pull/30) ] Support splitting of Connected Service proxy into multiple files
+* [ [#46](https://github.com/OData/ODataConnectedService/pull/46) ] Support emitting of service metadata to an XML file
 
 ## OData Connected Service 0.5.0
 
@@ -64,7 +64,7 @@ OData Connected Service extension is available on [Visual Studio Marketplace](ht
 * [ [#24](https://github.com/OData/ODataConnectedService/pull/24) ] Update Microsoft.OData.Client dependency to version 7.6.3
 
 ### New Features:
-* [ [#23](https://github.com/OData/ODataConnectedService/pull/23) ] Add built-in vocabulary models
+* [ [#23](https://github.com/OData/ODataConnectedService/pull/23) ] Make it possible to customize the built-in vocabulary models
 * [ [#26](https://github.com/OData/ODataConnectedService/pull/26) ] Support opening of generated Connected Service proxy files in IDE at completion
 * [ [#32](https://github.com/OData/ODataConnectedService/pull/32) ] Support mocking by making public methods `virtual`
 

--- a/Odata-docs/changelog/odataconnectedservice.md
+++ b/Odata-docs/changelog/odataconnectedservice.md
@@ -17,22 +17,21 @@ OData Connected Service extension is available on [Visual Studio Marketplace](ht
 * [ [#86](https://github.com/OData/ODataConnectedService/pull/86) ] Support for emitting service metadata to an XML file
 * [ [#100](https://github.com/OData/ODataConnectedService/pull/100) ] Support for excluding schema types from being emitted onto the Connected Service proxy class
 
-### Refinements and Bug Fixes
+### Improvements and Bug Fixes
 * [ [#66](https://github.com/OData/ODataConnectedService/pull/66) ] Use _var_ where the type of variable is clear from the context
 * [ [#97](https://github.com/OData/ODataConnectedService/pull/97) ] Fix multiple prompts when updating Connected Service with proxy split into multiple files
-* [ [#99](https://github.com/OData/ODataConnectedService/pull/99) ] Fix loading of saved configuration options when updating Connected Service/1
+* [ [#99](https://github.com/OData/ODataConnectedService/pull/99) & [#102](https://github.com/OData/ODataConnectedService/pull/102) ] Fix loading of saved configuration options when updating Connected Service
 * [ [#101](https://github.com/OData/ODataConnectedService/pull/101) ] Fix caption on Connected Service wizard
-* [ [#102](https://github.com/OData/ODataConnectedService/pull/102) ] Fix loading of saved configuration options when updating Connected Service/2
 
 ## OData Connected Service 0.8.0
 
-## New Features
+### New Features
 * [ [#50](https://github.com/OData/ODataConnectedService/pull/50) ] Support for loading configuration settings from a file
 * [ [#69](https://github.com/OData/ODataConnectedService/pull/69) ] Support for saving the configuration wizard state when navigating through the pages
 
 ## OData Connected Service 0.7.1
 
-## Bug Fix
+### Bug Fixes
 * [ [#77](https://github.com/OData/ODataConnectedService/pull/77) ] Fix bug causing service name to be reset to default value when updating Connected Service
 
 ## OData Connected Service 0.7.0


### PR DESCRIPTION
Update OData Connected Service changelog for release 0.7.0 to 0.9.0
Also incorporates feedback in #120 