### PR TITLE
Fix per https://github.com/dotnet/aspnetcore/issues/9542

### DIFF
--- a/Odata-docs/webapi/odata-advanced/sample/odata-expand/Startup.cs
+++ b/Odata-docs/webapi/odata-advanced/sample/odata-expand/Startup.cs
@@ -34,6 +34,8 @@ namespace ContosoUniversity
             services.AddDbContext<SchoolContext>(options =>
                options.UseInMemoryDatabase("OData-expand"));
 
+            services.AddMvc(option => option.EnableEndpointRouting = false);
+
             services.AddOData();
         }
 


### PR DESCRIPTION
Fixes the "Using 'UseMvc' to configure MVC is not supported while using Endpoint Routing. To continue using 'UseMvc', please set 'MvcOptions.EnableEndpointRounting = false' inside 'ConfigureServices'" error