### PR TITLE
Fixed typo

### DIFF
--- a/Odata-docs/webapi/first-odata-api.md
+++ b/Odata-docs/webapi/first-odata-api.md
@@ -245,7 +245,7 @@ The following Boolean conditions can be used with the OData `$filter`:
 
 |Condition | Description | Example |
 |--- | ---- | ---- |
-| eq | Equals to | $filter=priority et 1 |
+| eq | Equals to | $filter=priority eq 1 |
 | ne | Not equals to | $filter=priority ne 1 |
 | gt | Greater than  | $filter=priority gt 1 |
 | ge | Greater than or equal | $filter=priority ge 1 |


### PR DESCRIPTION
The example for Equals to was having `et` instead of `eq`.