### PR TITLE
Fix broken link

### DIFF
--- a/Odata-docs/TOC.yml
+++ b/Odata-docs/TOC.yml
@@ -155,7 +155,7 @@
           - name: Merge complex type and entity type
             href: /odata/webapi/merge-complex-and-entity
           - name: Query options in request body
-            href: /odata/webapi/query-options-in-request-body.md
+            href: /odata/webapi/query-options-in-request-body
       - name: Extending WebAPI
         items:
         - name: Custom URL parsing


### PR DESCRIPTION
Fix link to [Query options in request body] page that was broken (404) due to a trailing `.md` extension