### PR TITLE
Documentation for WebApi nested paths feature

### DIFF
--- a/Odata-docs/TOC.yml
+++ b/Odata-docs/TOC.yml
@@ -76,6 +76,8 @@
           href: /odata/webapi/built-in-routing-conventions
         - name: Attribute routing
           href: /odata/webapi/attribute-routing
+        - name: Automatic routing for nested paths with [EnableNestedPaths]
+          href: /odata/webapi/nested-paths-routing
         - name: Custom routing
           href: /odata/webapi/custom-routing-convention
       - name: How-to

--- a/Odata-docs/TOC.yml
+++ b/Odata-docs/TOC.yml
@@ -156,6 +156,8 @@
             href: /odata/webapi/merge-complex-and-entity
           - name: Query options in request body
             href: /odata/webapi/query-options-in-request-body
+          - name: Automatic support for nested paths with [EnableNestedPaths]
+            href: /odata/webapi/automatic-support-for-nested-paths-with-enable-nested-paths
       - name: Extending WebAPI
         items:
         - name: Custom URL parsing

--- a/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
+++ b/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
@@ -7,11 +7,11 @@ ms.author: clhabins
 ms.date: 8/09/2021
 ---
 # Automatic support for nested paths with [EnableNestedPaths]
-**Applies To**:[!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-core-v7.6.md)][!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-v7.6.md)]
+**Applies To**:[!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-core-v7.5.md)][!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-v7.5.md)]
 
 Usually, if you want to handle requests to nested resources, like `GET Customers(1)`, `GET Customers(1)/Orders`, `GET Customers(1)/Orders(1)`, you would need to implemen a separate controller action for each of them. Sometimes, the logic for retrieving an item by key or or a navigation property is as simple as making the corresponding LINQ query. In such cases, it would be handy to have an automated way of handling such requests.
 
-OData WebApi 7.6 introduced the `[EnableNestedPaths]` attribute which allows you to handle different `GET` requests that have a common navigation source (i.e. entity set or singleton) using only a single controller action.
+OData WebApi 7.5.9 introduced the `[EnableNestedPaths]` attribute which allows you to handle different `GET` requests that have a common navigation source (i.e. entity set or singleton) using only a single controller action.
 
 ## How it works
 
@@ -89,3 +89,4 @@ Path |  Actions
 - `[EnableNestedPaths]` currently does not accept any further configurations. In particular, you can not limit how deeply nested paths can be, you can limit which properties or navigation properties can be accessed, etc.
 - `[EnableNestedPaths]` only handles `GET` requests with entity set or singleton navigation sources. It does not handle functions or actions.
 - `[EnableNestedPaths]` does not handle $ref requests (i.e. `GET /Customers/1/Orders/1/$ref` will not be routed to the `Get()` method with `[EnableNestedPaths]`)
+- Currently only support on .NET Core (`Microsoft.AspNetCore.OData`)

--- a/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
+++ b/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
@@ -9,7 +9,7 @@ ms.date: 8/09/2021
 # Automatic support for nested paths with [EnableNestedPaths]
 **Applies To**:[!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-core-v7.5.md)]
 
-Usually, if you want to handle requests to nested resources, like `GET Customers(1)`, `GET Customers(1)/Orders`, `GET Customers(1)/Orders(1)`, you would need to implemen a separate controller action for each of them. Sometimes, the logic for retrieving an item by key or or a navigation property is as simple as making the corresponding LINQ query. In such cases, it would be handy to have an automated way of handling such requests.
+Usually, if you want to handle requests to nested resources, like `GET Customers(1)`, `GET Customers(1)/Orders`, `GET Customers(1)/Orders(1)`, you would need to implement a separate controller action for each of them. Sometimes, the logic for retrieving an item by key or or a navigation property is as simple as making the corresponding LINQ query. In such cases, it would be handy to have an automated way of handling such requests.
 
 OData WebApi 7.5.9 introduced the `[EnableNestedPaths]` attribute which allows you to handle different `GET` requests that have a common navigation source (i.e. entity set or singleton) using only a single controller action.
 
@@ -27,7 +27,7 @@ public class CustomersController {
 
 ```
 
-Now this `Get()` methods will handle `GET` requests that start with `Customers/` as the navigation source, e.e.g: `GET Customers`, `GET Customers(1)`, `GET Customers(1)/Orders`, `GET Customers(1)/Orders(1)`, `GET Customers(1)/Orders/$count`, etc.
+Now this `Get()` methods will handle `GET` requests that start with `Customers/` as the navigation source, e.g: `GET Customers`, `GET Customers(1)`, `GET Customers(1)/Orders`, `GET Customers(1)/Orders(1)`, `GET Customers(1)/Orders/$count`, etc.
 
 Under the hood, `[EnableNestedPaths]` will apply LINQ query transformations to the returned collection matching the requested path. For example, if the path contains a key segment, then a where clause will be applied to the query to filter the collection by the specified key. In the case of a navigation property segment, a select clause will be applied. If your returned collection is an `IQueryable` then the resulting query will be handled by the backend query provider, if it's an `IEnumerable` then the query will be evaluated in-memory.
 

--- a/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
+++ b/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
@@ -7,7 +7,7 @@ ms.author: clhabins
 ms.date: 8/09/2021
 ---
 # Automatic support for nested paths with [EnableNestedPaths]
-**Applies To**:[!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-core-v7.5.md)][!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-v7.5.md)]
+**Applies To**:[!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-core-v7.5.md)]
 
 Usually, if you want to handle requests to nested resources, like `GET Customers(1)`, `GET Customers(1)/Orders`, `GET Customers(1)/Orders(1)`, you would need to implemen a separate controller action for each of them. Sometimes, the logic for retrieving an item by key or or a navigation property is as simple as making the corresponding LINQ query. In such cases, it would be handy to have an automated way of handling such requests.
 
@@ -33,7 +33,7 @@ Under the hood, `[EnableNestedPaths]` will apply LINQ query transformations to t
 
 ## Support for singletons
 
-In the case of a singleton, you would wrap it with a [`SingleResult<T>`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnet.odata.singleresult-1):
+In the case of a singleton, you would wrap it with a [`SingleResult<T>`](/dotnet/api/microsoft.aspnet.odata.singleresult-1):
 
 ```c#
 public class TopCustomerController {

--- a/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
+++ b/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
@@ -90,3 +90,4 @@ Path |  Actions
 - `[EnableNestedPaths]` only handles `GET` requests with entity set or singleton navigation sources. It does not handle functions or actions.
 - `[EnableNestedPaths]` does not handle $ref requests (i.e. `GET /Customers/1/Orders/1/$ref` will not be routed to the `Get()` method with `[EnableNestedPaths]`)
 - This feature is currently only supported on .NET Core (`Microsoft.AspNetCore.OData`)
+- This feature is not yet available in `Microsoft.AspNetCore.OData` 8.x

--- a/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
+++ b/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
@@ -1,0 +1,91 @@
+---
+title: "Automatic support for nested paths withs [EnableNestedPaths]"
+description: "Describes how the [EnableNestedPaths] attribute can be used to supported nested paths"
+date: 2021-08-09 07:49:00
+author: habbes
+ms.author: clhabins
+ms.date: 8/09/2021
+---
+# Automatic support for nested paths with [EnableNestedPaths]
+**Applies To**:[!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-core-v7.6.md)][!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-v7.6.md)]
+
+Usually, if you want to handle requests to nested resources, like `GET Customers(1)`, `GET Customers(1)/Orders`, `GET Customers(1)/Orders(1)`, you would need to implemen a separate controller action for each of them. Sometimes, the logic for retrieving an item by key or or a navigation property is as simple as making the corresponding LINQ query. In such cases, it would be handy to have an automated way of handling such requests.
+
+OData WebApi 7.6 introduced the `[EnableNestedPaths]` attribute which allows you to handle different `GET` requests that have a common navigation source (i.e. entity set or singleton) using only a single controller action.
+
+## How it works
+
+To use this feature, you implement a `Get()` method in your controller that should return the collection corresponding to the navigation source being requested. For example, if you have an entity set called `Customers` you would implement a `Get()` method (or `GetCustomers()`) inside the `CustomersController` and return the `IQueryable` (or `IEnumerable`) representing the customers collection:
+
+```c#
+public class CustomersController {
+    [EnableNestedPaths]
+    public IQueryable<Customer> Get() {
+        return _dbContext.Customers;
+    }
+}
+
+```
+
+Now this `Get()` methods will handle `GET` requests that start with `Customers/` as the navigation source, e.e.g: `GET Customers`, `GET Customers(1)`, `GET Customers(1)/Orders`, `GET Customers(1)/Orders(1)`, `GET Customers(1)/Orders/$count`, etc.
+
+Under the hood, `[EnableNestedPaths]` will apply LINQ query transformations to the returned collection matching the requested path. For example, if the path contains a key segment, then a where clause will be applied to the query to filter the collection by the specified key. In the case of a navigation property segment, a select clause will be applied. If your returned collection is an `IQueryable` then the resulting query will be handled by the backend query provider, if it's an `IEnumerable` then the query will be evaluated in-memory.
+
+## Support for singletons
+
+In the case of a singleton, you would wrap it with a [`SingleResult<T>`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnet.odata.singleresult-1?view=odata-aspnetcore-7.0):
+
+```c#
+public class TopCustomerController {
+    [EnableNestedPaths]
+    public IQueryable<Customer> Get() {
+        return new SingleResult<Customer>(new [] { this.topCustomer });
+    }
+}
+```
+
+## Compatibility with `[EnableQuery]`
+
+You can use both `[EnableNestedPaths]` and `[EnableQuery]` on the same controller action:
+
+```c#
+public class CustomersController {
+    [EnableQuery]
+    [EnableNestedPaths]
+    public IQueryable<Customer> Get() { /* ... */ }
+}
+```
+
+ `[EnableNestedPaths]` will process the result first. `[EnableQuery]` will apply the query options to the result returned by `[EnableNestedPaths]`.
+
+## Conflict resolution with other routing conventions
+
+If your controller has other actions that handle specific requests like `Get(int key)`, `GetOrders(int key)`, etc., then those actions will take precedence. The `[EnableNestedPaths]` attribute only handles requests for which no other controller action is set to handle. To illustrate this point, let assume we have the following controller:
+
+```c#
+public class CustomersController {
+    [EnableNestedpaths]
+    public IQueryable<Customer> Get() { /* ... */ }
+
+    public IQueryable<Customer> Get(int key) { /* ... */ }
+
+    public IQueryable<Customer> GetOrders(int key) { /* ... */ }
+}
+```
+
+The following table shows which controller action different requests would be routed to:
+
+Path |  Actions
+-----|---------
+`/Customers` | `Get()`
+`/Customers(1)` | `Get(int key)`
+`/Customers(1)/Orders` | `GetOrders(int key)`
+`/Customers(1)/Name` | `Get()`
+`/Customers(1)/Orders(2)/Name` | `Get()`
+
+## Additional notes and limitaitons
+
+- The name of the controller action should be either `Get()` or `Get{NavigationSource}`
+- `[EnableNestedPaths]` currently does not accept any further configurations. In particular, you can not limit how deeply nested paths can be, you can limit which properties or navigation properties can be accessed, etc.
+- `[EnableNestedPaths]` only handles `GET` requests with entity set or singleton navigation sources. It does not handle functions or actions.
+- `[EnableNestedPaths]` does not handle $ref requests (i.e. `GET /Customers/1/Orders/1/$ref` will not be routed to the `Get()` method with `[EnableNestedPaths]`)

--- a/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
+++ b/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
@@ -33,7 +33,7 @@ Under the hood, `[EnableNestedPaths]` will apply LINQ query transformations to t
 
 ## Support for singletons
 
-In the case of a singleton, you would wrap it with a [`SingleResult<T>`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnet.odata.singleresult-1?view=odata-aspnetcore-7.0):
+In the case of a singleton, you would wrap it with a [`SingleResult<T>`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnet.odata.singleresult-1):
 
 ```c#
 public class TopCustomerController {

--- a/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
+++ b/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
@@ -69,7 +69,7 @@ public class CustomersController {
 
     public IQueryable<Customer> Get(int key) { /* ... */ }
 
-    public IQueryable<Customer> GetOrders(int key) { /* ... */ }
+    public IQueryable<Order> GetOrders(int key) { /* ... */ }
 }
 ```
 
@@ -83,7 +83,7 @@ Path |  Actions
 `/Customers(1)/Name` | `Get()`
 `/Customers(1)/Orders(2)/Name` | `Get()`
 
-## Additional notes and limitaitons
+## Additional notes and limitations
 
 - The name of the controller action should be either `Get()` or `Get{NavigationSource}`
 - `[EnableNestedPaths]` currently does not accept any further configurations. In particular, you can not limit how deeply nested paths can be, you can limit which properties or navigation properties can be accessed, etc.

--- a/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
+++ b/Odata-docs/webapi/automatic-nested-paths-with-enable-nested-paths.md
@@ -89,4 +89,4 @@ Path |  Actions
 - `[EnableNestedPaths]` currently does not accept any further configurations. In particular, you can not limit how deeply nested paths can be, you can limit which properties or navigation properties can be accessed, etc.
 - `[EnableNestedPaths]` only handles `GET` requests with entity set or singleton navigation sources. It does not handle functions or actions.
 - `[EnableNestedPaths]` does not handle $ref requests (i.e. `GET /Customers/1/Orders/1/$ref` will not be routed to the `Get()` method with `[EnableNestedPaths]`)
-- Currently only support on .NET Core (`Microsoft.AspNetCore.OData`)
+- This feature is currently only supported on .NET Core (`Microsoft.AspNetCore.OData`)

--- a/Odata-docs/webapi/nested-paths-routing.md
+++ b/Odata-docs/webapi/nested-paths-routing.md
@@ -1,0 +1,12 @@
+---
+title: "Nested paths routing"
+description: "Nested paths routing with [EnableNestedPaths]"
+date: 2021-08-09 07:49:00
+author: habbes
+ms.author: clhabins
+ms.date: 8/09/2021
+---
+# Nested paths routing
+**Applies To**:[!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-core-v7.6.md)][!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-v7.6.md)]
+
+Since OData WebApi v7.6, you can use the `[EnableNestedPaths]` attribute to handle routing of nested `GET` requests using a single `Get()` controller action, and the query transformations needed to fetch the data requesed in the path will be applied automatically. Visit [Automatic nested paths](/automatic-nested-paths-with-enable-nested-paths) guide to learn more about the feature.

--- a/Odata-docs/webapi/nested-paths-routing.md
+++ b/Odata-docs/webapi/nested-paths-routing.md
@@ -7,6 +7,6 @@ ms.author: clhabins
 ms.date: 8/09/2021
 ---
 # Nested paths routing
-**Applies To**:[!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-core-v7.6.md)][!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-v7.6.md)]
+**Applies To**:[!INCLUDE[appliesto-webapi](../includes/appliesto-webapi-core-v7.5.md)]
 
-Since OData WebApi v7.6, you can use the `[EnableNestedPaths]` attribute to handle routing of nested `GET` requests using a single `Get()` controller action, and the query transformations needed to fetch the data requesed in the path will be applied automatically. Visit [Automatic nested paths](/automatic-nested-paths-with-enable-nested-paths) guide to learn more about the feature.
+Starting with Microsoft.AspNetCore.OData v7.5.9, you can use the `[EnableNestedPaths]` attribute to handle routing of nested `GET` requests using a single `Get()` controller action, and the query transformations needed to fetch the data requesed in the path will be applied automatically. Visit [Automatic nested paths](/automatic-nested-paths-with-enable-nested-paths) guide to learn more about the feature.


### PR DESCRIPTION
Adds documentation for the feature that introduces "automatic" support for nested paths: https://github.com/OData/WebApi/pull/2456

I've added a brief page in the routing section and a more detailed guide in the how-to section.