### PR TITLE
Replace ActionResult with ActionResultOfT

### DIFF
--- a/Odata-docs/webapi-8/fundamentals/action-routing.md
+++ b/Odata-docs/webapi-8/fundamentals/action-routing.md
@@ -400,7 +400,7 @@ using Microsoft.AspNetCore.OData.Routing.Controllers;
 public class DefaultController : ODataController
 {
     [HttpPost("odata/ComputeSalary")]
-    public ActionResult ComputeSalary(ODataActionParameters parameters)
+    public ActionResult<decimal> ComputeSalary(ODataActionParameters parameters)
     {
         object hourlyRateAsObject, hoursWorkedAsObject;
         decimal hourlyRate;
@@ -415,7 +415,7 @@ public class DefaultController : ODataController
             return BadRequest();
         }
 
-        return Ok(hourlyRate * hoursWorked);
+        return hourlyRate * hoursWorked;
     }
 }
 ```

--- a/Odata-docs/webapi-8/fundamentals/entity-routing.md
+++ b/Odata-docs/webapi-8/fundamentals/entity-routing.md
@@ -184,7 +184,7 @@ GET http://localhost:5000/odata/Shapes(1)
 
 For the above request to be conventionally-routed, a controller action named `Get` (or `GetShape`) that accepts the key parameter is expected:
 ```csharp
-public ActionResult Get([FromRoute] int key)
+public ActionResult<Shape> Get([FromRoute] int key)
 {
     var shape = shapes.SingleOrDefault(d => d.Id.Equals(key));
 
@@ -193,7 +193,7 @@ public ActionResult Get([FromRoute] int key)
         return NotFound();
     }
 
-    return Ok(shape);
+    return shape;
 }
 ```
 
@@ -223,7 +223,7 @@ GET http://localhost:5000/odata/Shapes(2)/EntityRouting.Models.Circle
 
 For the above request to be conventionally-routed, a controller action named `GetCircle` that accepts the key parameter is expected:
 ```csharp
-public ActionResult GetCircle([FromRoute] int key)
+public ActionResult<Circle> GetCircle([FromRoute] int key)
 {
     var circle = shapes.OfType<Circle>().SingleOrDefault(d => d.Id.Equals(key));
 
@@ -232,7 +232,7 @@ public ActionResult GetCircle([FromRoute] int key)
         return NotFound();
     }
 
-    return Ok(circle);
+    return circle;
 }
 ```
 

--- a/Odata-docs/webapi-8/fundamentals/entityset-routing.md
+++ b/Odata-docs/webapi-8/fundamentals/entityset-routing.md
@@ -182,9 +182,9 @@ GET http://localhost:5000/odata/Shapes
 
 For the above request to be conventionally-routed, a controller action named `Get` (or `GetShapes`) is expected:
 ```csharp
-public ActionResult Get()
+public ActionResult<IEnumerable<Shape>> Get()
 {
-    return Ok(shapes);
+    return shapes;
 }
 ```
 
@@ -232,9 +232,9 @@ GET http://localhost:5000/odata/Shapes/$count
 For the above request to be conventionally-routed, a controller action named `Get` (or `GetShapes`) is expected, same as is expected when [retrieving an entity set](#retrieving-an-entity-set). However, the controller action needs to be decorated with `EnableQuery` attribute. The `EnableQuery` attribute is responsible for generating the relevant query for determining the number of items:
 ```csharp
 [EnableQuery]
-public ActionResult Get()
+public ActionResult<IEnumerable<Shape>> Get()
 {
-    return Ok(shapes);
+    return shapes;
 }
 ```
 
@@ -253,9 +253,9 @@ GET http://localhost:5000/odata/Shapes/EntitySetRouting.Models.Rectangle
 
 For the above request to be conventionally-routed, a controller action named `GetFromRectangle` (or `GetShapesFromRectangle`) is expected:
 ```csharp
-public ActionResult GetFromRectangle()
+public ActionResult<IEnumerable<Rectangle>> GetFromRectangle()
 {
-    return Ok(shapes.OfType<Rectangle>());
+    return shapes.OfType<Rectangle>().ToList();
 }
 ```
 
@@ -293,9 +293,9 @@ GET http://localhost:5000/odata/Shapes/EntitySetRouting.Models.Rectangle/$count
 For the above request to be conventionally-routed, a controller action named `GetFromRectangle` (or `GetShapesFromRectangle`) is expected, same as is expected when [retrieving a collection of derived entities](#retrieving-a-collection-of-derived-entities). However, the controller action needs to be decorated with `EnableQuery` attribute:
 ```csharp
 [EnableQuery]
-public ActionResult GetFromRectangle()
+public ActionResult<IEnumerable<Rectangle>> GetFromRectangle()
 {
-    return Ok(shapes.OfType<Rectangle>());
+    return shapes.OfType<Rectangle>().ToList();
 }
 ```
 

--- a/Odata-docs/webapi-8/fundamentals/function-routing.md
+++ b/Odata-docs/webapi-8/fundamentals/function-routing.md
@@ -206,14 +206,14 @@ The Edm organizes elements into a hierarchy. Based on our Edm model, `GetHighest
 For the above request to be conventionally-routed, a controller action named `GetHighestRating` that accepts no parameters is expected. The controller action should be decorated with `HttpGet` attribute:
 ```csharp
 [HttpGet]
-public ActionResult GetHighestRating()
+public ActionResult<decimal> GetHighestRating()
 {
     if (employees.Count < 1)
     {
         return NoContent();
     }
 
-    return Ok(employees.Select(d => d.PerfRating).OrderByDescending(d => d).First());
+    return employees.Select(d => d.PerfRating).OrderByDescending(d => d).First();
 }
 ```
 
@@ -243,7 +243,7 @@ GET http://localhost:5000/odata/Employees(1)/Default.GetRating()
 For the above request to be conventionally-routed, a controller action named `GetRating` that accepts the key parameter is expected. The controller action should be decorated with `HttpGet` attribute:
 ```csharp
 [HttpGet]
-public ActionResult GetRating([FromRoute] int key)
+public ActionResult<decimal> GetRating([FromRoute] int key)
 {
     var employee = employees.SingleOrDefault(d => d.Id.Equals(key));
 
@@ -252,7 +252,7 @@ public ActionResult GetRating([FromRoute] int key)
         return NotFound();
     }
 
-    return Ok(employee.PerfRating);
+    return employee.PerfRating;
 }
 ```
 
@@ -280,7 +280,7 @@ GET http://localhost:5000/odata/Employees/FunctionRouting.Models.Manager/Default
 For the above request to be conventionally-routed, a controller action named `GetHighestBonusOnCollectionOfManager` that accepts no parameters is expected. The controller action should be decorated with `HttpGet` attribute:
 ```csharp
 [HttpGet]
-public ActionResult GetHighestBonusOnCollectionOfManager()
+public ActionResult<decimal> GetHighestBonusOnCollectionOfManager()
 {
     var managers = employees.OfType<Manager>().ToArray();
 
@@ -289,7 +289,7 @@ public ActionResult GetHighestBonusOnCollectionOfManager()
         return NoContent();
     }
 
-    return Ok(managers.Select(d => d.Bonus).OrderByDescending(d => d).First());
+    return managers.Select(d => d.Bonus).OrderByDescending(d => d).First();
 }
 ```
 
@@ -319,7 +319,7 @@ GET http://localhost:5000/odata/Employees(5)/FunctionRouting.Models.Manager/Defa
 For the above request to be conventionally-routed, a controller action named `GetBonusOnManager` that accepts the key parameter is expected. The controller action should be decorated with `HttpGet` attribute:
 ```csharp
 [HttpGet]
-public ActionResult GetBonusOnManager([FromRoute] int key)
+public ActionResult<decimal> GetBonusOnManager([FromRoute] int key)
 {
     var manager = employees.OfType<Manager>().SingleOrDefault(d => d.Id.Equals(key));
 
@@ -328,7 +328,7 @@ public ActionResult GetBonusOnManager([FromRoute] int key)
         return NotFound();
     }
 
-    return Ok(manager.Bonus);
+    return manager.Bonus;
 }
 ```
 
@@ -358,9 +358,9 @@ In ASP.NET Core, the default route is one where the route prefix is an empty str
 public class DefaultController : ODataController
 {
     [HttpGet("odata/GetSalary(hourlyRate={hourlyRate},hoursWorked={hoursWorked})")]
-    public ActionResult GetSalary(decimal hourlyRate, int hoursWorked)
+    public ActionResult<decimal> GetSalary(decimal hourlyRate, int hoursWorked)
     {
-        return Ok(hourlyRate * hoursWorked);
+        return hourlyRate * hoursWorked;
     }
 }
 ```

--- a/Odata-docs/webapi-8/fundamentals/navigation-routing.md
+++ b/Odata-docs/webapi-8/fundamentals/navigation-routing.md
@@ -196,7 +196,7 @@ GET http://localhost:5000/odata/Employees(1)/Supervisor
 
 For the above request to be conventionally-routed, a controller action named `GetSupervisor` that accepts the key parameter is expected:
 ```csharp
-public ActionResult GetSupervisor([FromRoute] int key)
+public ActionResult<Employee> GetSupervisor([FromRoute] int key)
 {
     var employee = employees.SingleOrDefault(d => d.Id.Equals(key));
 
@@ -205,7 +205,7 @@ public ActionResult GetSupervisor([FromRoute] int key)
         return NotFound();
     }
 
-    return Ok(employee.Supervisor);
+    return employee.Supervisor;
 }
 ```
 
@@ -231,7 +231,7 @@ GET http://localhost:5000/odata/Employees(5)/NavigationRouting.Models.Manager/Di
 
 For the above request to be conventionally-routed, a controller action named `GetDirectReportsFromManager` that accepts the key parameter is expected:
 ```csharp
-public ActionResult GetDirectReportsFromManager([FromRoute] int key)
+public ActionResult<IEnumerable<Employee>> GetDirectReportsFromManager([FromRoute] int key)
 {
     var manager = employees.OfType<Manager>().SingleOrDefault(d => d.Id.Equals(key));
 
@@ -240,7 +240,7 @@ public ActionResult GetDirectReportsFromManager([FromRoute] int key)
         return NotFound();
     }
 
-    return Ok(manager.DirectReports);
+    return manager.DirectReports;
 }
 ```
 
@@ -280,7 +280,7 @@ GET http://localhost:5000/odata/Employees(5)/NavigationRouting.Models.Manager/Di
 For the above request to be conventionally-routed, a controller action named `GetDirectReportsFromManager` that accepts the key parameter is expected, same as is expected when retrieving a collection-valued navigation property. However, the controller action needs to be decorated with `EnableQuery` attribute:
 ```csharp
 [EnableQuery]
-public ActionResult GetDirectReportsFromManager([FromRoute] int key)
+public ActionResult<IEnumerable<Employee>> GetDirectReportsFromManager([FromRoute] int key)
 {
     var manager = employees.OfType<Manager>().SingleOrDefault(d => d.Id.Equals(key));
 
@@ -289,7 +289,7 @@ public ActionResult GetDirectReportsFromManager([FromRoute] int key)
         return NotFound();
     }
 
-    return Ok(manager.DirectReports);
+    return manager.DirectReports;
 }
 ```
 

--- a/Odata-docs/webapi-8/fundamentals/property-routing.md
+++ b/Odata-docs/webapi-8/fundamentals/property-routing.md
@@ -263,7 +263,7 @@ GET http://localhost:5000/odata/Customers(1)/BillingAddress
 
 For the above request to be conventionally-routed, a controller action named `GetBillingAddress` that accepts the key parameter is expected:
 ```csharp
-public ActionResult GetBillingAddress([FromRoute] int key)
+public ActionResult<Address> GetBillingAddress([FromRoute] int key)
 {
     var customer = customers.SingleOrDefault(d => d.Id.Equals(key));
 
@@ -272,7 +272,7 @@ public ActionResult GetBillingAddress([FromRoute] int key)
         return NotFound();
     }
 
-    return Ok(customer.BillingAddress);
+    return customer.BillingAddress;
 }
 ```
 
@@ -299,7 +299,7 @@ The cast segment (e.g. `/PropertyRouting.Models.PostalAddress`) serves the purpo
 
 For the above request to be conventionally-routed, a controller action named `GetBillingAddressOfPostalAddress` that accepts the key parameter is expected:
 ```csharp
-public ActionResult GetBillingAddressOfPostalAddress([FromRoute] int key)
+public ActionResult<PostalAddress> GetBillingAddressOfPostalAddress([FromRoute] int key)
 {
     var customer = customers.SingleOrDefault(d => d.Id.Equals(key));
 
@@ -308,7 +308,7 @@ public ActionResult GetBillingAddressOfPostalAddress([FromRoute] int key)
         return NotFound();
     }
 
-    return Ok(billingAddress);
+    return billingAddress;
 }
 ```
 
@@ -349,7 +349,7 @@ GET http://localhost:5000/odata/Customers(3)/PropertyRouting.Models.EnterpriseCu
 
 For the above request to be conventionally-routed, a controller action named `GetRegisteredAddressFromEnterpriseCustomer` that accepts the key parameter is expected:
 ```csharp
-public ActionResult GetRegisteredAddressFromEnterpriseCustomer([FromRoute] int key)
+public ActionResult<Address> GetRegisteredAddressFromEnterpriseCustomer([FromRoute] int key)
 {
     var enterpriseCustomer = customers.OfType<EnterpriseCustomer>().SingleOrDefault(d => d.Id.Equals(key));
 
@@ -358,7 +358,7 @@ public ActionResult GetRegisteredAddressFromEnterpriseCustomer([FromRoute] int k
         return NotFound();
     }
 
-    return Ok(enterpriseCustomer.RegisteredAddress);
+    return enterpriseCustomer.RegisteredAddress;
 }
 ```
 
@@ -383,7 +383,7 @@ GET http://localhost:5000/odata/Customers(4)/PropertyRouting.Models.EnterpriseCu
 
 For the above request to be conventionally-routed, a controller action named `GetRegisteredAddressOfPostalAddressFromEnterpriseCustomer` that accepts the key parameter is expected:
 ```csharp
-public ActionResult GetRegisteredAddressOfPostalAddressFromEnterpriseCustomer([FromRoute] int key)
+public ActionResult<PostalAddress> GetRegisteredAddressOfPostalAddressFromEnterpriseCustomer([FromRoute] int key)
 {
     var enterpriseCustomer = customers.OfType<EnterpriseCustomer>().SingleOrDefault(d => d.Id.Equals(key));
 
@@ -392,7 +392,7 @@ public ActionResult GetRegisteredAddressOfPostalAddressFromEnterpriseCustomer([F
         return NotFound();
     }
 
-    return Ok(registeredAddress);
+    return registeredAddress;
 }
 ```
 
@@ -448,7 +448,7 @@ GET http://localhost:5000/odata/Customers(3)/PropertyRouting.Models.EnterpriseCu
 
 For the above request to be conventionally-routed, a controller action named `GetCreditLimitFromEnterpriseCustomer` that accepts the key parameter is expected:
 ```csharp
-public ActionResult GetCreditLimitFromEnterpriseCustomer([FromRoute] int key)
+public ActionResult<decimal> GetCreditLimitFromEnterpriseCustomer([FromRoute] int key)
 {
     var enterpriseCustomer = customers.OfType<EnterpriseCustomer>().SingleOrDefault(d => d.Id.Equals(key));
 
@@ -457,7 +457,7 @@ public ActionResult GetCreditLimitFromEnterpriseCustomer([FromRoute] int key)
         return NotFound();
     }
 
-    return Ok(enterpriseCustomer.CreditLimit);
+    return enterpriseCustomer.CreditLimit;
 }
 ```
 
@@ -482,7 +482,7 @@ GET http://localhost:5000/odata/Customers(1)/ContactPhones/$count
 For the above request to be conventionally-routed, a controller action named `GetContactPhones` that accepts the key parameter is expected. The action should be decorated with `EnableQuery` attribute. The `EnableQuery` attribute is responsible for generating the relevant query for determining the number of items:
 ```csharp
 [EnableQuery]
-public ActionResult GetContactPhones([FromRoute] int key)
+public ActionResult<IEnumerable<string>> GetContactPhones([FromRoute] int key)
 {
     var customer = customers.SingleOrDefault(d => d.Id.Equals(key));
 
@@ -491,7 +491,7 @@ public ActionResult GetContactPhones([FromRoute] int key)
         return NotFound();
     }
 
-    return Ok(customer.ContactPhones);
+    return customer.ContactPhones;
 }
 ```
 

--- a/Odata-docs/webapi-8/fundamentals/routing-overview.md
+++ b/Odata-docs/webapi-8/fundamentals/routing-overview.md
@@ -113,18 +113,18 @@ using Microsoft.AspNetCore.OData.Routing.Controllers;
 public class CustomersController : ODataController
 {
     [EnableQuery]
-    public ActionResult Get()
+    public ActionResult<IEnumerable<Customer>> Get()
     {
-        return Ok(new List<Customer>
+        return new List<Customer>
         {
             new Customer { Id = 1, Name = "Customer 1" },
             new Customer { Id = 2, Name = "Customer 2" }
-        });
+        };
     }
 
-    public ActionResult Get([FromRoute] int key)
+    public ActionResult<Customer> Get([FromRoute] int key)
     {
-        return Ok(new Customer { Id = key, Name = $"Customer {key}" });
+        return new Customer { Id = key, Name = $"Customer {key}" };
     }
 }
 
@@ -153,19 +153,19 @@ public class CustomersController : ODataController
 {
     [EnableQuery]
     [HttpGet("odata/Customers")]
-    public ActionResult List()
+    public ActionResult<IEnumerable<Customer>> List()
     {
-        return Ok(new List<Customer>
+        return new List<Customer>
         {
             new Customer { Id = 1, Name = "Customer 1" },
             new Customer { Id = 2, Name = "Customer 2" }
-        });
+        };
     }
 
     [HttpGet("odata/Customers({key})")]
-    public ActionResult Details([FromRoute] int key)
+    public ActionResult<Customer> Details([FromRoute] int key)
     {
-        return Ok(new Customer { Id = key, Name = $"Customer {key}" });
+        return new Customer { Id = key, Name = $"Customer {key}" };
     }
 }
 ```

--- a/Odata-docs/webapi-8/fundamentals/singleton-routing.md
+++ b/Odata-docs/webapi-8/fundamentals/singleton-routing.md
@@ -178,9 +178,9 @@ GET http://localhost:5000/odata/Company
 
 For the above request to be conventionally-routed, a controller action named `Get` (or `GetCompany`) is expected:
 ```csharp
-public ActionResult Get()
+public ActionResult<Company> Get()
 {
-    return Ok(company);
+    return company;
 }
 ```
 
@@ -205,14 +205,14 @@ GET http://localhost:5000/odata/Company/SingletonRouting.Models.HoldingCompany
 
 For the above request to be conventionally-routed, a controller action named `GetFromHoldingCompany` is expected:
 ```csharp
-public ActionResult GetFromHoldingCompany()
+public ActionResult<HoldingCompany> GetFromHoldingCompany()
 {
     if (!(company is HoldingCompany holdingCompany))
     {
         return NotFound();
     }
 
-    return Ok(holdingCompany);
+    return holdingCompany;
 }
 ```
 

--- a/Odata-docs/webapi-8/getting-started.md
+++ b/Odata-docs/webapi-8/getting-started.md
@@ -142,13 +142,13 @@ namespace Lab01.Controllers
             }));
 
         [EnableQuery]
-        public ActionResult Get()
+        public ActionResult<IEnumerable<Customer>> Get()
         {
             return Ok(customers);
         }
 
         [EnableQuery]
-        public ActionResult Get([FromRoute] int key)
+        public ActionResult<Customer> Get([FromRoute] int key)
         {
             var item = customers.SingleOrDefault(d => d.Id.Equals(key));
 

--- a/Odata-docs/webapi-8/tutorials/basic-crud.md
+++ b/Odata-docs/webapi-8/tutorials/basic-crud.md
@@ -337,7 +337,7 @@ In the sections that follow, we implement support for different CRUD operations.
 ## Request entity collection
 To support the ability to return all `Customer` entities from an OData service, we implement a controller action to handle that request. Add the following logic to the `CustomersController` class:
 ```csharp
-public ActionResult Get()
+public ActionResult<IQueryable<Customer>> Get()
 {
     return Ok(db.Customers);
 }
@@ -376,7 +376,7 @@ The following JSON payload shows the expected response:
 ## Request a single entity
 To support this request, we add a controller action named `Get` (or `GetCustomer`) to the `CustomersController` class. The action should accept a single parameter named `key` of type `int` - same type as the entity's key property:
 ```csharp
-public ActionResult Get([FromRoute] int key)
+public ActionResult<Customer> Get([FromRoute] int key)
 {
     var customer = db.Customers.SingleOrDefault(d => d.Id == key);
 


### PR DESCRIPTION
Replace `ActionResult` with `ActionResult<T>` in code samples where a controller action returns a value.
Justification: Improved type-checking

RE: https://github.com/OData/AspNetCoreOData/issues/805#issuecomment-1428128420