### PR TITLE
Update getting-started.md

### DIFF
--- a/Odata-docs/webapi-8/getting-started.md
+++ b/Odata-docs/webapi-8/getting-started.md
@@ -150,14 +150,8 @@ namespace Lab01.Controllers
         [EnableQuery]
         public ActionResult<Customer> Get([FromRoute] int key)
         {
-            var item = customers.SingleOrDefault(d => d.Id.Equals(key));
-
-            if (item == null)
-            {
-                return NotFound();
-            }
-
-            return Ok(item);
+            var item = customers.AsQueryable().Where(c=>c.Id==key);           
+            return SingleResult.Create(item);
         }
     }
 }


### PR DESCRIPTION
Adapt get method by key

An odata endpoint must return a IQueryable.
If you evaluate it directly in the return of the controller method, the odata query options can't working.
If you directly return the queryable you return an array with only one element.
You can fix that with the usage of 
SingleResult.Create method form odata