### PR TITLE
Include ODL 8 release notes in published docs.

### DIFF
--- a/Odata-docs/TOC.yml
+++ b/Odata-docs/TOC.yml
@@ -247,7 +247,7 @@
     - name: What's new
       items:
         - name: What's new in OData .NET 8
-          href: /odata/odatalib/whats-new/odatalib-8
+          href: /odata/odatalib/release-notes/odatalib-8
     - name: Core lib
       items:
         - name: Write OData payload

--- a/Odata-docs/docfx.json
+++ b/Odata-docs/docfx.json
@@ -36,6 +36,13 @@
         "files": [
           "*.{md,yml}"
         ],
+        "src": "odatalib/release-notes",
+        "dest": "odatalib/release-notes"
+      },
+      {
+        "files": [
+          "*.{md,yml}"
+        ],
         "src": "client/v6",
         "dest": "client"
       },

--- a/Odata-docs/includes/appliesto-odataclient-v8.md
+++ b/Odata-docs/includes/appliesto-odataclient-v8.md
@@ -8,10 +8,3 @@ author: habbes
 # OData client v8 supported
 
  ![OData Client V8](/odata/assets/doc-assets/yes.png) OData Client V8
-
-
-## `Microsoft.OData.Core`
-
-### Default JSON writer changed
-
-The

--- a/Odata-docs/odatalib/release-notes/odatalib-8.md
+++ b/Odata-docs/odatalib/release-notes/odatalib-8.md
@@ -2,13 +2,14 @@
 title:  "What's new in OData .NET 8"
 description: Get an overview of new features and changes in OData.NET 8 and guides to help you migrate from OData .NET 7.
 date:   2024-08-05
-ms.date: 08/05/2024
+ms.date: 8/5/2024
 author: habbes
 ms.author: clhabins
 ---
 
 # What's new in OData .NET 8.0
-**Applies To**:[!INCLUDE[appliesto-webapi](../includes/appliesto-odatalib-v8.md)] [!INCLUDE[appliesto-webapi](../includes/appliesto-odataclient-v8.md)]
+
+**Applies To**:[!INCLUDE[appliesto-odatalib](../../includes/appliesto-odatalib-v8.md)] [!INCLUDE[appliesto-webapi](../../includes/appliesto-odataclient-v8.md)]
 
 ## Target Framework
 
@@ -31,8 +32,8 @@ This writer has some notable changes in how some values are handled during seria
 
 The default writer in version 8 uses uppercase letters for unicode code points, the default in version 7 uses lowercase letters
 
-- OData.NET v7 default writer: "Cust1 \ud800\udc05 \u00e4"
-- OData .NET v8 default writer: "Cust1 \uD800\uDC05 \u00E4"
+- OData .NET v7 default writer: `"Cust1 \ud800\udc05 \u00e4"`
+- OData .NET v8 default writer: `"Cust1 \uD800\uDC05 \u00E4"`
 
 Both versions are valid and equivalent, compliant clients should handle them the same way.
 

--- a/Odata-docs/support/support-policy.md
+++ b/Odata-docs/support/support-policy.md
@@ -43,7 +43,7 @@ OData.NET libraries in this context refer to `Microsoft.OData.Core`, `Microsoft.
 
 ### OData.NET 8.x
 
-OData.NET 8 is the next major release of the OData.NET libraries, including `Microsoft.OData.Core` 8, `Microsoft.OData.Edm` 8, `Microsoft.Spatial` 8 and `Microsoft.OData.Client` 8.
+OData.NET 8 is the current major release of the OData.NET libraries, including `Microsoft.OData.Core` 8, `Microsoft.OData.Edm` 8, `Microsoft.Spatial` 8 and `Microsoft.OData.Client` 8.
 These libraries will only support .NET 8 and later.
 
 OData.NET 8 will support the following OData protocal versions:


### PR DESCRIPTION
The "What's new in OData .NET 8" page is not getting rendered in the docs. This is because the odatalib folder is excluded from publishing in the docfx.json configuration. Subfolders that should be included for publishing should be individually included. I've included the release-notes subfolder in the config.