### PR TITLE
Remove postman

### DIFF
--- a/Odata-docs/webapi/first-odata-api.md
+++ b/Odata-docs/webapi/first-odata-api.md
@@ -55,8 +55,7 @@ Returning `System.Linq.IQueryable` or `ActionResult<IQueryable>` enables **OData
 
 ## Query resources using OData
 
-Post some data to the web API app, using a tool such as [HTTP REPL](/aspnet/core/web-api/http-repl) or [Postman](https://www.postman.com/product/tools).
-
+Post some data to the web API app, using a tool such as [HTTP REPL](/aspnet/core/web-api/http-repl) or [curl](https://curl.haxx.se/).
 Send 5 Post requests to `https://localhost:5001/api/todo` with the 5 items below **separately** in the request body.
 
 ```json

--- a/Odata-docs/webapi/odata-expand.md
+++ b/Odata-docs/webapi/odata-expand.md
@@ -39,17 +39,10 @@ The preceding code enables OData queries and returns enrollment entities `School
 
 OData `expand` functionality can be used to query related data. For example, to get the *Course* data for each *Enrollment* entity, include `?$expand=course` at the end of the request path:
 
+Use a tool such as [HTTP REPL](/aspnet/core/web-api/http-repl) or [HTTP REPL](/aspnet/core/web-api/http-repl) or [curl](https://curl.haxx.se/) to test the web API:
 This tutorial uses Postman to test the web API.
 
-* Install [Postman](https://www.getpostman.com/apps)
-* Start the web app.
-* Start Postman.
-* Disable **SSL certificate verification**
-  
-  * From  **File > Settings** (**General* tab), disable **SSL certificate verification**.
-    > [!WARNING]
-    > Re-enable SSL certificate verification after testing the controller.
-
+* Start the web app. and the endpoint testing tool.
 * Create a new request.
   * Set the HTTP method to `GET`.
   * Set the request URL to `https://localhost:5001/api/Enrollment/?$expand=course($expand=Department)`. Change the port as necessary.

--- a/Odata-docs/webapi/odata-expand.md
+++ b/Odata-docs/webapi/odata-expand.md
@@ -40,7 +40,6 @@ The preceding code enables OData queries and returns enrollment entities `School
 OData `expand` functionality can be used to query related data. For example, to get the *Course* data for each *Enrollment* entity, include `?$expand=course` at the end of the request path:
 
 Use a tool such as [HTTP REPL](/aspnet/core/web-api/http-repl) or [HTTP REPL](/aspnet/core/web-api/http-repl) or [curl](https://curl.haxx.se/) to test the web API:
-This tutorial uses Postman to test the web API.
 
 * Start the web app. and the endpoint testing tool.
 * Create a new request.
@@ -107,7 +106,7 @@ Replace the `EnableQuery` attribute with `MyEnableQuery` attribute in the `Enrol
 
 [!code-csharp[](odata-advanced/sample/odata-expand/Controllers/EnrollmentController.cs?name=snippet_MyEnableQuery)]
 
-In Postman:
+In the endpoint testing tool:
 
 * Send the previous `Get` request `https://localhost:5001/api/Enrollment/?$expand=course($expand=Department)`. The request returns data because `($expand=Department)` is not prohibited.
 * Send a `Get` request for with `($expand=CourseAssignments)`. For example, `https://localhost:5001/api/Enrollment/?$expand=course($expand=CourseAssignments)`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 ## Microsoft Open Source Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
Fixes  [#33326](https://github.com/dotnet/AspNetCore.Docs/issues/33326) 
- [ ] [Odata-docs/webapi/first-odata-api.md](https://github.com/MicrosoftDocs/OData-docs/blob/main/Odata-docs/webapi/first-odata-api.md)
- [ ] [Odata-docs/webapi/odata-expand.md](https://github.com/MicrosoftDocs/OData-docs/blob/main/Odata-docs/webapi/odata-expand.md)

Well know [vunerability](https://cybersecuritynews.com/postman-api-testing-platform-flaw/) among others. This is part of a MSFT wide Postman replacement sweep.

@habbes @xuzhg @gathogojr please review