### PR TITLE
Add documentation for using DataserviceContext IHttpClientFactory in OData Client

### DIFF
--- a/Odata-docs/client/using-dataservice-ihttpclientfactory.md
+++ b/Odata-docs/client/using-dataservice-ihttpclientfactory.md
@@ -2,7 +2,7 @@
 title: "Using DataserviceContext IHttpClientFactory in Microsoft.OData.Client"
 description: "This tutorial provides guidance on using IHttpClientFactory with OData Client in a .NET application."
 
-author: WanjohiSammy
+author: Wanjohi Sammy
 ms.author: swanjohi
 ms.date: 11/29/2024
 ms.topic: article

--- a/Odata-docs/client/using-dataservice-ihttpclientfactory.md
+++ b/Odata-docs/client/using-dataservice-ihttpclientfactory.md
@@ -12,22 +12,22 @@ ms.topic: article
 
 This feature was introduced in [OData.NET 8](/odata/odatalib/release-notes/odatalib-8#added-support-for-ihttpclientfactory).
 
-`Microsoft.OData.Client` uses `HttpClient` by default, but this document will guide you on how to configure `HttpClient` by providing settings like timeouts and custom handlers using `IHttpClientFactory`.
+`Microsoft.OData.Client` uses [`HttpClient`](/dotnet/api/system.net.http.httpclient) by default, but this document will guide you on how to configure `HttpClient` by providing settings like timeouts and custom handlers using `IHttpClientFactory`.
 
 ## Why Use IHttpClientFactory?
 
 [`IHttpClientFactory`](/dotnet/core/extensions/httpclient-factory) is a feature in .NET Core that helps you manage `HttpClient` instances. Here are some benefits:
-- **Automatic Management**: It handles the lifecycle of HttpClient instances, preventing issues like socket exhaustion.
+- **Automatic Management**: It handles the lifecycle of `HttpClient` instances, preventing issues like socket exhaustion.
 - **Configuration**: You can set up policies like retries and timeouts.
 - **Dependency Injection**: It integrates with .NET Core's DI system, making it easy to use in your services.
 
 ## Getting Started
 
-To customize **HttpClient** with `Microsoft.OData.Client`, you can use the `HttpClientFactory` property of `DataServiceContext`. This lets you inject your custom HttpClient instance.
+To customize **`HttpClient`** with `Microsoft.OData.Client`, you can use the `HttpClientFactory` property of `DataServiceContext`. This lets you inject your custom `HttpClient` instance.
 
 ### 1. Using Dependency Injection
 
-You can use the [`IHttpClientFactory with .NET`](/dotnet/core/extensions/dependency-injection) to configure and inject HttpClient instances. 
+You can use the [`IHttpClientFactory with .NET`](/dotnet/core/extensions/dependency-injection) to configure and inject `HttpClient` instances. 
 
 > **Note that we use an `empty string` here since `OData Client` does not detect `named clients`.**
 Here's how:
@@ -51,7 +51,7 @@ var context = new Container(new Uri("{Your endpoint here. For example, https://l
 
 ### 2. Create a Custom HttpClientFactory
 
-Alternatively, you can create a custom HttpClientFactory:
+Alternatively, you can create a custom `HttpClientFactory`:
 
 ```cs
 public class CustomHttpClientFactory : IHttpClientFactory
@@ -70,7 +70,7 @@ public class CustomHttpClientFactory : IHttpClientFactory
 }
 ```
 
-Next, create an HttpClient instance and set the timeout:
+Next, create an `HttpClient` instance and set the timeout:
 
 ```cs
 var httpClient = new HttpClient
@@ -89,10 +89,10 @@ var context = new Container(new Uri("{Your endpoint here. For example, https://l
 ## Additional Resources
 
 For more details, check out:
-- [Added support for IHttpClientFactory in OData.NET 8](/odata/odatalib/release-notes/odatalib-8#added-support-for-ihttpclientfactory)
-- [Use HttpClient in OData.NET 7 Client](/odata/client/using-httpclient)
+- [Added support for `IHttpClientFactory` in `OData.NET 8`](/odata/odatalib/release-notes/odatalib-8#added-support-for-ihttpclientfactory)
+- [Use `HttpClient` in OData.NET 7 Client](/odata/client/using-httpclient)
 
 ## Conclusion
-Using IHttpClientFactory with Microsoft.OData.Client makes managing HttpClient instances easier and more efficient. Whether you create a custom HttpClientFactory or use the DI system, integrating HttpClient with your OData client is straightforward.
+Using `IHttpClientFactory` with `Microsoft.OData.Client` makes managing and customizing `HttpClient` instances easier. Whether you create a custom `HttpClientFactory` or use the DI system, integrating `HttpClient` with your OData client is straightforward.
 
 Happy coding!

--- a/Odata-docs/client/using-dataservice-ihttpclientfactory.md
+++ b/Odata-docs/client/using-dataservice-ihttpclientfactory.md
@@ -2,7 +2,7 @@
 title: "Configuring HttpClient with IHttpClientFactory in Microsoft.OData.Client"
 description: "This tutorial provides guidance on configuring HttpClient with IHttpClientFactory in OData.NET 8"
 
-author: Wanjohi Sammy
+author: WanjohiSammy
 ms.author: swanjohi
 ms.date: 11/29/2024
 ms.topic: article

--- a/Odata-docs/client/using-dataservice-ihttpclientfactory.md
+++ b/Odata-docs/client/using-dataservice-ihttpclientfactory.md
@@ -30,6 +30,7 @@ To customize **`HttpClient`** with `Microsoft.OData.Client`, you can use the `Ht
 You can use the [`IHttpClientFactory with .NET`](/dotnet/core/extensions/dependency-injection) to configure and inject `HttpClient` instances. 
 
 > **Note that we use an `empty string` here since `OData Client` does not detect `named clients`.**
+
 Here's how:
 
 ```cs
@@ -89,7 +90,7 @@ var context = new Container(new Uri("{Your endpoint here. For example, https://l
 ## Additional Resources
 
 For more details, check out:
-- [Added support for `IHttpClientFactory` in `OData.NET 8`](/odata/odatalib/release-notes/odatalib-8#added-support-for-ihttpclientfactory)
+- [Added support for `IHttpClientFactory` in OData.NET 8](/odata/odatalib/release-notes/odatalib-8#added-support-for-ihttpclientfactory)
 - [Use `HttpClient` in OData.NET 7 Client](/odata/client/using-httpclient)
 
 ## Conclusion

--- a/Odata-docs/client/using-dataservice-ihttpclientfactory.md
+++ b/Odata-docs/client/using-dataservice-ihttpclientfactory.md
@@ -1,10 +1,21 @@
+---
+title: "Using DataserviceContext IHttpClientFactory in Microsoft.OData.Client"
+description: "This tutorial provides guidance on using IHttpClientFactory with OData Client in a .NET application."
+
+author: WanjohiSammy
+ms.author: swanjohi
+ms.date: 11/29/2024
+ms.topic: article
+ 
+---
+
 # Using DataserviceContext IHttpClientFactory in Microsoft.OData.Client
 
-Ever wanted to use `HttpClient` with [`Microsoft.OData.Client`](https://learn.microsoft.com/odata/client/getting-started)? Now you can! In this post, we'll show you how to do it easily and highlight the benefits.
+Ever wanted to use `HttpClient` with [`Microsoft.OData.Client`](/odata/client/getting-started)? Now you can! In this post, we'll show you how to do it easily and highlight the benefits.
 
 ## Why Use IHttpClientFactory?
 
-[`IHttpClientFactory`](https://learn.microsoft.com/dotnet/core/extensions/httpclient-factory) is a feature in .NET Core that helps you manage `HttpClient` instances. Here are some benefits:
+[`IHttpClientFactory`](/dotnet/core/extensions/httpclient-factory) is a feature in .NET Core that helps you manage `HttpClient` instances. Here are some benefits:
 - **Automatic Management**: It handles the lifecycle of HttpClient instances, preventing issues like socket exhaustion.
 - **Configuration**: You can set up policies like retries and timeouts.
 - **Dependency Injection**: It integrates with .NET Core's DI system, making it easy to use in your services.
@@ -15,7 +26,7 @@ To use **HttpClient** with `Microsoft.OData.Client`, you can use the `HttpClient
 
 ### 1. Using Dependency Injection
 
-You can use the [`IHttpClientFactory with .NET`](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection) to configure and inject HttpClient instances. 
+You can use the [`IHttpClientFactory with .NET`](/dotnet/core/extensions/dependency-injection) to configure and inject HttpClient instances. 
 
 > **Note that we use an `empty string` here since `OData Client` does not detect `named clients`.**
 
@@ -79,7 +90,7 @@ var context = new Container(new Uri("https://localhost:7214/odata"))
 
 For more details, check out:
 - [Breaking changes in Microsoft.OData.Client](https://devblogs.microsoft.com/odata/odata-net-8-preview-release/#breaking-changes-in-microsoft.odata.client)
-- [Use HttpClient in OData Client](https://learn.microsoft.com/odata/client/using-httpclient)
+- [Use HttpClient in OData Client](/odata/client/using-httpclient)
 
 ## Conclusion
 Using IHttpClientFactory with Microsoft.OData.Client makes managing HttpClient instances easier and more efficient. Whether you create a custom HttpClientFactory or use the DI system, integrating HttpClient with your OData client is straightforward.

--- a/Odata-docs/client/using-dataservice-ihttpclientfactory.md
+++ b/Odata-docs/client/using-dataservice-ihttpclientfactory.md
@@ -1,10 +1,10 @@
 # Using DataserviceContext IHttpClientFactory in Microsoft.OData.Client
 
-Ever wanted to use `HttpClient` with `Microsoft.OData.Client`? Now you can! In this post, we'll show you how to do it easily and highlight the benefits.
+Ever wanted to use `HttpClient` with [`Microsoft.OData.Client`](https://learn.microsoft.com/odata/client/getting-started)? Now you can! In this post, we'll show you how to do it easily and highlight the benefits.
 
 ## Why Use IHttpClientFactory?
 
-IHttpClientFactory is a feature in .NET Core that helps you manage HttpClient instances. Here are some benefits:
+[`IHttpClientFactory`](https://learn.microsoft.com/dotnet/core/extensions/httpclient-factory) is a feature in .NET Core that helps you manage `HttpClient` instances. Here are some benefits:
 - **Automatic Management**: It handles the lifecycle of HttpClient instances, preventing issues like socket exhaustion.
 - **Configuration**: You can set up policies like retries and timeouts.
 - **Dependency Injection**: It integrates with .NET Core's DI system, making it easy to use in your services.
@@ -13,9 +13,35 @@ IHttpClientFactory is a feature in .NET Core that helps you manage HttpClient in
 
 To use **HttpClient** with `Microsoft.OData.Client`, you can use the `HttpClientFactory` property of `DataServiceContext`. This lets you inject your custom HttpClient instance.
 
-### Step 1: Create a Custom HttpClientFactory
+### 1. Using Dependency Injection
 
-First, create a custom HttpClientFactory:
+You can use the [`IHttpClientFactory with .NET`](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection) to configure and inject HttpClient instances. 
+
+> **Note that we use an `empty string` here since `OData Client` does not detect `named clients`.**
+
+Here's how:
+
+```cs
+var services = new ServiceCollection();
+
+services.AddHttpClient("", client => // We should use an empty string here since OData Client does not detect named clients.
+{
+    client.Timeout = TimeSpan.FromSeconds(160);
+});
+
+var serviceProvider = services.BuildServiceProvider();
+var httpClientFactory = serviceProvider.GetRequiredService();
+
+var context = new Container(new Uri("https://localhost:7214/odata"))
+{
+    HttpClientFactory = httpClientFactory
+};
+```
+
+### 2. Create a Custom HttpClientFactory
+
+Alternatively, you can create a custom HttpClientFactory:
+
 ```cs
 public class CustomHttpClientFactory : IHttpClientFactory
 {
@@ -33,9 +59,8 @@ public class CustomHttpClientFactory : IHttpClientFactory
 }
 ```
 
-### Step 2: Create and Configure HttpClient
-
 Next, create an HttpClient instance and set the timeout:
+
 ```cs
 var httpClient = new HttpClient
 {
@@ -50,31 +75,11 @@ var context = new Container(new Uri("https://localhost:7214/odata"))
 };
 ```
 
-### Step 3: Using Dependency Injection
-
-You can also use the .NET Core DI system:
-```cs
-var services = new ServiceCollection();
-
-services.AddHttpClient("", client =>
-{
-    client.Timeout = TimeSpan.FromSeconds(160);
-});
-
-var serviceProvider = services.BuildServiceProvider();
-var httpClientFactory = serviceProvider.GetRequiredService();
-
-var context = new Container(new Uri("https://localhost:7214/odata"))
-{
-    HttpClientFactory = httpClientFactory
-};
-```
-
 ## Additional Resources
 
 For more details, check out:
 - [Breaking changes in Microsoft.OData.Client](https://devblogs.microsoft.com/odata/odata-net-8-preview-release/#breaking-changes-in-microsoft.odata.client)
-- [Use HttpClient in OData Client](https://learn.microsoft.com/en-us/odata/client/using-httpclient)
+- [Use HttpClient in OData Client](https://learn.microsoft.com/odata/client/using-httpclient)
 
 ## Conclusion
 Using IHttpClientFactory with Microsoft.OData.Client makes managing HttpClient instances easier and more efficient. Whether you create a custom HttpClientFactory or use the DI system, integrating HttpClient with your OData client is straightforward.

--- a/Odata-docs/client/using-dataservice-ihttpclientfactory.md
+++ b/Odata-docs/client/using-dataservice-ihttpclientfactory.md
@@ -1,0 +1,82 @@
+# Using DataserviceContext IHttpClientFactory in Microsoft.OData.Client
+
+Ever wanted to use `HttpClient` with `Microsoft.OData.Client`? Now you can! In this post, we'll show you how to do it easily and highlight the benefits.
+
+## Why Use IHttpClientFactory?
+
+IHttpClientFactory is a feature in .NET Core that helps you manage HttpClient instances. Here are some benefits:
+- **Automatic Management**: It handles the lifecycle of HttpClient instances, preventing issues like socket exhaustion.
+- **Configuration**: You can set up policies like retries and timeouts.
+- **Dependency Injection**: It integrates with .NET Core's DI system, making it easy to use in your services.
+
+## Getting Started
+
+To use **HttpClient** with `Microsoft.OData.Client`, you can use the `HttpClientFactory` property of `DataServiceContext`. This lets you inject your custom HttpClient instance.
+
+### Step 1: Create a Custom HttpClientFactory
+
+First, create a custom HttpClientFactory:
+```cs
+public class CustomHttpClientFactory : IHttpClientFactory
+{
+    private readonly HttpClient _httpClient;
+
+    public CustomHttpClientFactory(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public HttpClient CreateClient(string name)
+    {
+        return _httpClient;
+    }
+}
+```
+
+### Step 2: Create and Configure HttpClient
+
+Next, create an HttpClient instance and set the timeout:
+```cs
+var httpClient = new HttpClient
+{
+    Timeout = TimeSpan.FromSeconds(160)
+};
+
+var httpClientFactory = new CustomHttpClientFactory(httpClient);
+
+var context = new Container(new Uri("https://localhost:7214/odata"))
+{
+    HttpClientFactory = httpClientFactory
+};
+```
+
+### Step 3: Using Dependency Injection
+
+You can also use the .NET Core DI system:
+```cs
+var services = new ServiceCollection();
+
+services.AddHttpClient("", client =>
+{
+    client.Timeout = TimeSpan.FromSeconds(160);
+});
+
+var serviceProvider = services.BuildServiceProvider();
+var httpClientFactory = serviceProvider.GetRequiredService();
+
+var context = new Container(new Uri("https://localhost:7214/odata"))
+{
+    HttpClientFactory = httpClientFactory
+};
+```
+
+## Additional Resources
+
+For more details, check out:
+- [Breaking changes in Microsoft.OData.Client](https://devblogs.microsoft.com/odata/odata-net-8-preview-release/#breaking-changes-in-microsoft.odata.client)
+- [Use HttpClient in OData Client](https://learn.microsoft.com/en-us/odata/client/using-httpclient)
+
+## Conclusion
+Using IHttpClientFactory with Microsoft.OData.Client makes managing HttpClient instances easier and more efficient. Whether you create a custom HttpClientFactory or use the DI system, integrating HttpClient with your OData client is straightforward.
+
+Happy coding!

--- a/Odata-docs/client/using-dataservice-ihttpclientfactory.md
+++ b/Odata-docs/client/using-dataservice-ihttpclientfactory.md
@@ -1,6 +1,6 @@
 ---
-title: "Using DataserviceContext IHttpClientFactory in Microsoft.OData.Client"
-description: "This tutorial provides guidance on using IHttpClientFactory with OData Client in a .NET application."
+title: "Configuring HttpClient with IHttpClientFactory in Microsoft.OData.Client"
+description: "This tutorial provides guidance on configuring HttpClient with IHttpClientFactory in OData.NET 8"
 
 author: Wanjohi Sammy
 ms.author: swanjohi

--- a/Odata-docs/client/using-dataservice-ihttpclientfactory.md
+++ b/Odata-docs/client/using-dataservice-ihttpclientfactory.md
@@ -6,12 +6,13 @@ author: Wanjohi Sammy
 ms.author: swanjohi
 ms.date: 11/29/2024
 ms.topic: article
- 
 ---
 
-# Using DataserviceContext IHttpClientFactory in Microsoft.OData.Client
+# Configuring HttpClient with IHttpClientFactory in Microsoft.OData.Client
 
-Ever wanted to use `HttpClient` with [`Microsoft.OData.Client`](/odata/client/getting-started)? Now you can! In this post, we'll show you how to do it easily and highlight the benefits.
+This feature was introduced in [OData.NET 8](/odata/odatalib/release-notes/odatalib-8#added-support-for-ihttpclientfactory).
+
+`Microsoft.OData.Client` uses `HttpClient` by default, but this document will guide you on how to configure `HttpClient` by providing settings like timeouts and custom handlers using `IHttpClientFactory`.
 
 ## Why Use IHttpClientFactory?
 
@@ -22,14 +23,13 @@ Ever wanted to use `HttpClient` with [`Microsoft.OData.Client`](/odata/client/ge
 
 ## Getting Started
 
-To use **HttpClient** with `Microsoft.OData.Client`, you can use the `HttpClientFactory` property of `DataServiceContext`. This lets you inject your custom HttpClient instance.
+To customize **HttpClient** with `Microsoft.OData.Client`, you can use the `HttpClientFactory` property of `DataServiceContext`. This lets you inject your custom HttpClient instance.
 
 ### 1. Using Dependency Injection
 
 You can use the [`IHttpClientFactory with .NET`](/dotnet/core/extensions/dependency-injection) to configure and inject HttpClient instances. 
 
 > **Note that we use an `empty string` here since `OData Client` does not detect `named clients`.**
-
 Here's how:
 
 ```cs
@@ -43,7 +43,7 @@ services.AddHttpClient("", client => // We should use an empty string here since
 var serviceProvider = services.BuildServiceProvider();
 var httpClientFactory = serviceProvider.GetRequiredService();
 
-var context = new Container(new Uri("https://localhost:7214/odata"))
+var context = new Container(new Uri("{Your endpoint here. For example, https://localhost:7214/odata}"))
 {
     HttpClientFactory = httpClientFactory
 };
@@ -80,7 +80,7 @@ var httpClient = new HttpClient
 
 var httpClientFactory = new CustomHttpClientFactory(httpClient);
 
-var context = new Container(new Uri("https://localhost:7214/odata"))
+var context = new Container(new Uri("{Your endpoint here. For example, https://localhost:7214/odata}"))
 {
     HttpClientFactory = httpClientFactory
 };
@@ -89,8 +89,8 @@ var context = new Container(new Uri("https://localhost:7214/odata"))
 ## Additional Resources
 
 For more details, check out:
-- [Breaking changes in Microsoft.OData.Client](https://devblogs.microsoft.com/odata/odata-net-8-preview-release/#breaking-changes-in-microsoft.odata.client)
-- [Use HttpClient in OData Client](/odata/client/using-httpclient)
+- [Added support for IHttpClientFactory in OData.NET 8](/odata/odatalib/release-notes/odatalib-8#added-support-for-ihttpclientfactory)
+- [Use HttpClient in OData.NET 7 Client](/odata/client/using-httpclient)
 
 ## Conclusion
 Using IHttpClientFactory with Microsoft.OData.Client makes managing HttpClient instances easier and more efficient. Whether you create a custom HttpClientFactory or use the DI system, integrating HttpClient with your OData client is straightforward.


### PR DESCRIPTION
## Description

This PR adds comprehensive documentation on how to use IHttpClientFactory with Microsoft.OData.Client.

[View the Doc here](https://github.com/WanjohiSammy/OData-docs/blob/swanjohi/use-dataservicecontext-ihttpclientfactory/Odata-docs/client/using-dataservice-ihttpclientfactory.md)