### PR TITLE
Parameter name error

### DIFF
--- a/Odata-docs/webapi/key-value-binding.md
+++ b/Odata-docs/webapi/key-value-binding.md
@@ -69,7 +69,7 @@ Now, you can issue a request:
 
 ```html
 
-GET https://~/odata/Customers(StringKey='my',DateKey=2016-05-11,GuidKey=46538EC2-E497-4DFE-A039-1C22F0999D6C)
+GET https://~/odata/Customers(StringProp='my',DateProp=2016-05-11,GuidProp=46538EC2-E497-4DFE-A039-1C22F0999D6C)
 
 ```
 


### PR DESCRIPTION
Key is used as prefix and the names of parameters are suffixed by Prop